### PR TITLE
2 installsh bør støtte å kjøre uten  r opsjon

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @statens-pensjonskasse/team-applikasjonsplattform

--- a/install.sh
+++ b/install.sh
@@ -88,9 +88,9 @@ INSTALLDIR="${1:-}"
 [[ -d "$INSTALLDIR" ]] || Fail "Installasjonskatalog $INSTALLDIR eksisterer ikke."
 
 if [[ "$STRICT_VERSION" = true ]]; then
-    FILENAME="commit-msg-strict"
+    FILENAME="$(dirname "$(realpath "$0")")/commit-msg-strict"
 else
-    FILENAME="commit-msg"
+    FILENAME="$(dirname "$(realpath "$0")")/commit-msg"
 fi
 
 if [[ $RECURSIVE = true ]] ; then

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ fi
 if [[ $RECURSIVE = true ]] ; then
     RECURSIVE_TEXT="REKURSIVT"
 fi
-if ! PromptToContinue "Ønsker du å installere $FILENAME hooks $RECURSIVE_TEXT in $INSTALLDIR?" ; then
+if ! PromptToContinue "Ønsker du å installere hooken $FILENAME ${RECURSIVE_TEXT:-} i $INSTALLDIR?" ; then
     exit 1
 fi
 


### PR DESCRIPTION
Det var jo en teit feil...

La også merke til at du kjørte scriptet fra katalogen du vil ha hook'en i, og ikke fra dette repoet, noe som egentlig ikke var støttet - men nå er det det.